### PR TITLE
bugs fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ next-env.d.ts
 /.idea
 
 *storybook.log
+/data/

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ next-env.d.ts
 
 *storybook.log
 /data/
+
+certificates

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -H 0.0.0.0 -p 3000",
     "build": "next build",
     "start": "next start",
     "lint": "eslint -c .eslintrc.json --ext .js,.jsx,.ts,.tsx src --quiet --fix",

--- a/src/app/[locale]/add/components/DepositAmounts/TokenDepositCard.tsx
+++ b/src/app/[locale]/add/components/DepositAmounts/TokenDepositCard.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import { ChangeEvent, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import { NumericFormat } from "react-number-format";
 import { formatUnits } from "viem";
 import { useAccount, useBalance, useBlockNumber } from "wagmi";
@@ -27,29 +27,48 @@ export const InputRange = ({
   onChange,
 }: {
   value: number;
-  onChange: (value: 0 | 100) => void;
+  // onChange: (value: 0 | 100) => void;
+  onChange: (value: number) => void;
 }) => {
+  const [locValue, setValue] = useState(value);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    console.log(`handleChange: ${event.target.value}`);
+    setValue(parseInt(event.target.value));
+    // onChange(locValue);
+  };
+
+  const handleMouseUp = () => {
+    let newValue = locValue >= 50 ? 100 : 0;
+    console.log(`handleMouseUp: ${newValue}`);
+    setValue(newValue);
+    onChange(newValue);
+  };
+
   return (
     <div className="relative h-6">
       <input
-        value={value}
+        value={locValue}
         max={100}
-        step={100}
+        step={5}
         min={0}
-        onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(+e.target.value as 0 | 100)}
+        onChange={handleChange}
+        onMouseUp={handleMouseUp}
+        onTouchEnd={handleMouseUp}
         className={clsx(
           "w-full accent-green absolute top-2 left-0 right-0 duration-200 !bg-purple",
-          value < 50 && "variant-purple",
+          locValue < 50 && "variant-purple",
         )}
         type="range"
       />
       <div
         className="pointer-events-none absolute bg-green h-2 rounded-1 left-0 top-2"
-        style={{ width: value === 1 ? 0 : `calc(${value}% - 2px)` }}
+        style={{ width: value === 1 ? 0 : `calc(${locValue}% - 2px)` }}
       />
     </div>
   );
 };
+
 function InputTotalAmount({
   currency,
   value,
@@ -291,8 +310,10 @@ export default function TokenDepositCard({
   onChange: (value: string) => void;
   isDisabled: boolean;
   isOutOfRange: boolean;
-  tokenStandardRatio: 0 | 100;
-  setTokenStandardRatio: (ratio: 0 | 100) => void;
+  // tokenStandardRatio: 0 | 100;
+  tokenStandardRatio: number;
+  // setTokenStandardRatio: (ratio: 0 | 100) => void;
+  setTokenStandardRatio: (ratio: number) => void;
   gasPrice?: bigint;
 }) {
   const t = useTranslations("Liquidity");

--- a/src/app/[locale]/add/components/LiquidityActionButton/LiquidityActionButton.tsx
+++ b/src/app/[locale]/add/components/LiquidityActionButton/LiquidityActionButton.tsx
@@ -35,7 +35,7 @@ export const LiquidityActionButton = ({
   const tWallet = useTranslations("Wallet");
   const { setIsOpen } = useConfirmLiquidityDialogStore();
 
-  const { setStatus } = useAddLiquidityStatusStore();
+  const { setStatus, setApprove0Status, setApprove0Hash, setApprove1Status, setApprove1Hash } = useAddLiquidityStatusStore();
   const { tokenA, tokenB } = useAddLiquidityTokensStore();
   const { tier } = useLiquidityTierStore();
   const { price } = usePriceRange();
@@ -159,6 +159,10 @@ export const LiquidityActionButton = ({
         fullWidth
         onClick={() => {
           setStatus(AddLiquidityStatus.INITIAL);
+          setApprove0Status(0);
+          setApprove0Hash(undefined);
+          setApprove1Status(0);
+          setApprove1Hash(undefined);
           setIsOpen(true);
         }}
       >

--- a/src/app/[locale]/add/components/LiquidityActionButton/LiquidityActionButton.tsx
+++ b/src/app/[locale]/add/components/LiquidityActionButton/LiquidityActionButton.tsx
@@ -35,7 +35,8 @@ export const LiquidityActionButton = ({
   const tWallet = useTranslations("Wallet");
   const { setIsOpen } = useConfirmLiquidityDialogStore();
 
-  const { setStatus, setApprove0Status, setApprove0Hash, setApprove1Status, setApprove1Hash } = useAddLiquidityStatusStore();
+  const { setStatus, setApprove0Status, setApprove0Hash, setApprove1Status, setApprove1Hash } =
+    useAddLiquidityStatusStore();
   const { tokenA, tokenB } = useAddLiquidityTokensStore();
   const { tier } = useLiquidityTierStore();
   const { price } = usePriceRange();

--- a/src/app/[locale]/add/components/LiquidityActionButton/TransactionItem.tsx
+++ b/src/app/[locale]/add/components/LiquidityActionButton/TransactionItem.tsx
@@ -81,19 +81,22 @@ export const TransactionItem = ({
 
           <div className="flex items-center gap-2 justify-end">
             {localValueBigInt !== amount &&
-            ![AddLiquidityApproveStatus.PENDING, AddLiquidityApproveStatus.LOADING].includes(
-              status,
-            ) ? (
-              <div
-                className="flex gap-2 text-green cursor-pointer"
-                onClick={() => {
-                  updateValue(formatUnits(amount, token.decimals));
-                }}
-              >
-                <span>Set Default</span>
-                <Svg iconName="reset" />
-              </div>
-            ) : null}
+              ![
+                AddLiquidityApproveStatus.PENDING,
+                AddLiquidityApproveStatus.LOADING,
+                AddLiquidityApproveStatus.SUCCESS,
+              ].includes(status) && (
+                <div
+                  className="flex gap-2 text-green cursor-pointer"
+                  onClick={() => {
+                    updateValue(formatUnits(amount, token.decimals));
+                  }}
+                >
+                  <span>Set Default</span>
+                  <Svg iconName="reset" />
+                </div>
+              )}
+
             {hash && (
               <a
                 target="_blank"

--- a/src/app/[locale]/add/hooks/useLiquidityApprove.tsx
+++ b/src/app/[locale]/add/hooks/useLiquidityApprove.tsx
@@ -1,12 +1,12 @@
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { Address } from "viem";
 import { usePublicClient } from "wagmi";
 
 import { useStoreAllowance } from "@/hooks/useAllowance";
 import useCurrentChainId from "@/hooks/useCurrentChainId";
 import { useStoreDeposit } from "@/hooks/useDeposit";
-import useDetectMetaMaskMobile from "@/hooks/useMetamaskMobile";
+// import useDetectMetaMaskMobile from "@/hooks/useMetamaskMobile";
 import { NONFUNGIBLE_POSITION_MANAGER_ADDRESS } from "@/sdk_hybrid/addresses";
 import { DexChainId } from "@/sdk_hybrid/chains";
 import { Currency } from "@/sdk_hybrid/entities/currency";
@@ -40,9 +40,9 @@ export enum ApproveTransactionType {
 }
 
 export const useLiquidityApprove = () => {
-  const isMetamaskMobile = useDetectMetaMaskMobile();
+  // const isMetamaskMobile = useDetectMetaMaskMobile();
 
-  const { gasSettings, gasModel, customGasLimit } = useAddLiquidityGasSettings();
+  const { gasSettings } = useAddLiquidityGasSettings(); // not used:  , gasModel, customGasLimit
   const {
     approve0Status,
     approve1Status,
@@ -224,74 +224,75 @@ export const useLiquidityApprove = () => {
       if (!publicClient) {
         return;
       }
-      if (
-        tokenA?.isToken &&
-        tokenAStandard === Standard.ERC20 &&
-        (currentAllowanceA || BigInt(0)) < amountA
-      ) {
-        openConfirmInWalletAlert(t("confirm_action_in_your_wallet_alert"));
 
-        setApprove0Status(AddLiquidityApproveStatus.PENDING);
-        const result = await approveA({
-          customAmount: customAmountA,
-          customGasSettings: gasSettings,
-        });
-        if (!result?.success) {
-          setApprove0Status(AddLiquidityApproveStatus.ERROR);
-          closeConfirmInWalletAlert();
-        } else {
-          setApprove0Hash(result.hash);
-          setApprove0Status(AddLiquidityApproveStatus.LOADING);
-          closeConfirmInWalletAlert();
+      if (approve0Status !== AddLiquidityApproveStatus.SUCCESS) {
+        if (
+          tokenA?.isToken &&
+          tokenAStandard === Standard.ERC20 &&
+          (currentAllowanceA || BigInt(0)) < amountA
+        ) {
+          openConfirmInWalletAlert(t("confirm_action_in_your_wallet_alert"));
 
-          const approveReceipt = await publicClient.waitForTransactionReceipt({
-            hash: result.hash,
+          setApprove0Status(AddLiquidityApproveStatus.PENDING);
+          const result = await approveA({
+            customAmount: customAmountA,
+            customGasSettings: gasSettings,
           });
-
-          if (approveReceipt.status === "reverted") {
+          if (!result?.success) {
             setApprove0Status(AddLiquidityApproveStatus.ERROR);
+            closeConfirmInWalletAlert();
           } else {
-            setApprove0Status(AddLiquidityApproveStatus.SUCCESS);
+            setApprove0Hash(result.hash);
+            setApprove0Status(AddLiquidityApproveStatus.LOADING);
+            closeConfirmInWalletAlert();
+
+            const approveReceipt = await publicClient.waitForTransactionReceipt({
+              hash: result.hash,
+            });
+
+            if (approveReceipt.status === "reverted") {
+              setApprove0Status(AddLiquidityApproveStatus.ERROR);
+            } else {
+              setApprove0Status(AddLiquidityApproveStatus.SUCCESS);
+            }
           }
+        } else if (
+          tokenA?.isToken &&
+          tokenAStandard === Standard.ERC223 &&
+          (currentDepositA || BigInt(0)) < amountA
+        ) {
+          openConfirmInWalletAlert(t("confirm_action_in_your_wallet_alert"));
 
-          if (customAmountB) {
-            await handleApprove1({ customAmountB });
-          }
-        }
-      } else if (
-        tokenA?.isToken &&
-        tokenAStandard === Standard.ERC223 &&
-        (currentDepositA || BigInt(0)) < amountA
-      ) {
-        openConfirmInWalletAlert(t("confirm_action_in_your_wallet_alert"));
-
-        setDeposite0Status(AddLiquidityApproveStatus.PENDING);
-        const result = await depositA({
-          customAmount: customAmountA,
-          customGasSettings: gasSettings,
-        });
-        if (!result?.success) {
-          setDeposite0Status(AddLiquidityApproveStatus.ERROR);
-          closeConfirmInWalletAlert();
-        } else {
-          setDeposite0Hash(result.hash);
-          setDeposite0Status(AddLiquidityApproveStatus.LOADING);
-          closeConfirmInWalletAlert();
-
-          const depositeReceipt = await publicClient.waitForTransactionReceipt({
-            hash: result.hash,
+          setDeposite0Status(AddLiquidityApproveStatus.PENDING);
+          const result = await depositA({
+            customAmount: customAmountA,
+            customGasSettings: gasSettings,
           });
-
-          if (depositeReceipt.status === "reverted") {
+          if (!result?.success) {
             setDeposite0Status(AddLiquidityApproveStatus.ERROR);
+            closeConfirmInWalletAlert();
           } else {
-            setDeposite0Status(AddLiquidityApproveStatus.SUCCESS);
-          }
+            setDeposite0Hash(result.hash);
+            setDeposite0Status(AddLiquidityApproveStatus.LOADING);
+            closeConfirmInWalletAlert();
 
-          if (customAmountB) {
-            await handleApprove1({ customAmountB });
+            const depositeReceipt = await publicClient.waitForTransactionReceipt({
+              hash: result.hash,
+            });
+
+            if (depositeReceipt.status === "reverted") {
+              setDeposite0Status(AddLiquidityApproveStatus.ERROR);
+            } else {
+              setDeposite0Status(AddLiquidityApproveStatus.SUCCESS);
+            }
           }
         }
+      }
+
+      console.log('end of approve0');
+      if (customAmountB || amountToCheckB) {
+        console.log('calling approve1 in end');
+        await handleApprove1({ customAmountB });
       }
     },
     [
@@ -321,67 +322,69 @@ export const useLiquidityApprove = () => {
         return;
       }
 
-      if (
-        tokenB?.isToken &&
-        tokenBStandard === Standard.ERC20 &&
-        (currentAllowanceB || BigInt(0)) < amountB
-      ) {
-        openConfirmInWalletAlert(t("confirm_action_in_your_wallet_alert"));
+      if (![AddLiquidityApproveStatus.SUCCESS, AddLiquidityApproveStatus.LOADING].includes(approve1Status)) {
+        if (
+          tokenB?.isToken &&
+          tokenBStandard === Standard.ERC20 &&
+          (currentAllowanceB || BigInt(0)) < amountB
+        ) {
+          openConfirmInWalletAlert(t("confirm_action_in_your_wallet_alert"));
 
-        setApprove1Status(AddLiquidityApproveStatus.PENDING);
-        const result = await approveB({
-          customAmount: customAmountB,
-          customGasSettings: gasSettings,
-        });
-
-        if (!result?.success) {
-          setApprove1Status(AddLiquidityApproveStatus.ERROR);
-          closeConfirmInWalletAlert();
-          // return;
-        } else {
-          setApprove1Hash(result.hash);
-          setApprove1Status(AddLiquidityApproveStatus.LOADING);
-          closeConfirmInWalletAlert();
-
-          const approveReceipt = await publicClient.waitForTransactionReceipt({
-            hash: result.hash,
+          setApprove1Status(AddLiquidityApproveStatus.PENDING);
+          const result = await approveB({
+            customAmount: customAmountB,
+            customGasSettings: gasSettings,
           });
 
-          if (approveReceipt.status === "reverted") {
+          if (!result?.success) {
             setApprove1Status(AddLiquidityApproveStatus.ERROR);
+            closeConfirmInWalletAlert();
             // return;
           } else {
-            setApprove1Status(AddLiquidityApproveStatus.SUCCESS);
+            setApprove1Hash(result.hash);
+            setApprove1Status(AddLiquidityApproveStatus.LOADING);
+            closeConfirmInWalletAlert();
+
+            const approveReceipt = await publicClient.waitForTransactionReceipt({
+              hash: result.hash,
+            });
+
+            if (approveReceipt.status === "reverted") {
+              setApprove1Status(AddLiquidityApproveStatus.ERROR);
+              // return;
+            } else {
+              setApprove1Status(AddLiquidityApproveStatus.SUCCESS);
+            }
           }
-        }
-      } else if (
-        tokenB?.isToken &&
-        tokenBStandard === Standard.ERC223 &&
-        (currentDepositB || BigInt(0)) < amountB
-      ) {
-        openConfirmInWalletAlert(t("confirm_action_in_your_wallet_alert"));
+        } else if (
+          tokenB?.isToken &&
+          tokenBStandard === Standard.ERC223 &&
+          (currentDepositB || BigInt(0)) < amountB
+        ) {
+          openConfirmInWalletAlert(t("confirm_action_in_your_wallet_alert"));
 
-        setDeposite1Status(AddLiquidityApproveStatus.PENDING);
-        const result = await depositB({
-          customAmount: customAmountB,
-          customGasSettings: gasSettings,
-        });
-        if (!result?.success) {
-          setDeposite1Status(AddLiquidityApproveStatus.ERROR);
-          closeConfirmInWalletAlert();
-        } else {
-          setDeposite1Hash(result.hash);
-          setDeposite1Status(AddLiquidityApproveStatus.LOADING);
-          closeConfirmInWalletAlert();
-
-          const depositeReceipt = await publicClient.waitForTransactionReceipt({
-            hash: result.hash,
+          setDeposite1Status(AddLiquidityApproveStatus.PENDING);
+          const result = await depositB({
+            customAmount: customAmountB,
+            customGasSettings: gasSettings,
           });
-
-          if (depositeReceipt.status === "reverted") {
+          if (!result?.success) {
             setDeposite1Status(AddLiquidityApproveStatus.ERROR);
+            closeConfirmInWalletAlert();
           } else {
-            setDeposite1Status(AddLiquidityApproveStatus.SUCCESS);
+            setDeposite1Hash(result.hash);
+            setDeposite1Status(AddLiquidityApproveStatus.LOADING);
+            closeConfirmInWalletAlert();
+
+            const depositeReceipt = await publicClient.waitForTransactionReceipt({
+              hash: result.hash,
+            });
+
+            if (depositeReceipt.status === "reverted") {
+              setDeposite1Status(AddLiquidityApproveStatus.ERROR);
+            } else {
+              setDeposite1Status(AddLiquidityApproveStatus.SUCCESS);
+            }
           }
         }
       }
@@ -414,11 +417,12 @@ export const useLiquidityApprove = () => {
       customAmountA?: bigint;
       customAmountB?: bigint;
     }) => {
-      if (isMetamaskMobile) {
-        await handleApprove0({ customAmountA, customAmountB });
-      } else {
-        await Promise.all([handleApprove0({ customAmountA }), handleApprove1({ customAmountB })]);
-      }
+      // NOTE perform approves in query on ANY wallet (most wallets can process only ONE request at a time)
+      // if (isMetamaskMobile) {
+      await handleApprove0({ customAmountA, customAmountB });
+      // } else {
+      //   await Promise.all([handleApprove0({ customAmountA }), handleApprove1({ customAmountB })]);
+      // }
     },
     [handleApprove0, handleApprove1],
   );

--- a/src/app/[locale]/add/hooks/useLiquidityApprove.tsx
+++ b/src/app/[locale]/add/hooks/useLiquidityApprove.tsx
@@ -289,9 +289,7 @@ export const useLiquidityApprove = () => {
         }
       }
 
-      console.log('end of approve0');
       if (customAmountB || amountToCheckB) {
-        console.log('calling approve1 in end');
         await handleApprove1({ customAmountB });
       }
     },
@@ -322,7 +320,11 @@ export const useLiquidityApprove = () => {
         return;
       }
 
-      if (![AddLiquidityApproveStatus.SUCCESS, AddLiquidityApproveStatus.LOADING].includes(approve1Status)) {
+      if (
+        ![AddLiquidityApproveStatus.SUCCESS, AddLiquidityApproveStatus.LOADING].includes(
+          approve1Status,
+        )
+      ) {
         if (
           tokenB?.isToken &&
           tokenBStandard === Standard.ERC20 &&

--- a/src/app/[locale]/add/page.tsx
+++ b/src/app/[locale]/add/page.tsx
@@ -7,6 +7,7 @@ import React, { useCallback, useState } from "react";
 import FeeAmountSettings from "@/app/[locale]/add/components/FeeAmountSettings";
 import { useAddLiquidityTokensStore } from "@/app/[locale]/add/stores/useAddLiquidityTokensStore";
 import { useLiquidityTierStore } from "@/app/[locale]/add/stores/useLiquidityTierStore";
+import { useSwapRecentTransactionsStore } from "@/app/[locale]/swap/stores/useSwapRecentTransactions";
 import Container from "@/components/atoms/Container";
 import SelectButton from "@/components/atoms/SelectButton";
 import IconButton, {
@@ -35,7 +36,10 @@ export default function AddPoolPage() {
   usePoolsSearchParams();
   useRecentTransactionTracking();
   const [isOpenedTokenPick, setIsOpenedTokenPick] = useState(false);
-  const [showRecentTransactions, setShowRecentTransactions] = useState(true);
+  // const [showRecentTransactions, setShowRecentTransactions] = useState(true);
+  const { isOpened: showRecentTransactions, setIsOpened: setShowRecentTransactions } =
+    useSwapRecentTransactionsStore();
+
   const t = useTranslations("Liquidity");
 
   const router = useRouter();
@@ -122,12 +126,10 @@ export default function AddPoolPage() {
           <h2 className="text-18 md:text-20 font-bold">{t("add_liquidity_title")}</h2>
           <div className="w-[48px] md:w-[104px] flex items-center gap-2 justify-end">
             <IconButton
-              variant={IconButtonVariant.DEFAULT}
               buttonSize={IconButtonSize.LARGE}
               iconName="recent-transactions"
               active={showRecentTransactions}
               onClick={() => setShowRecentTransactions(!showRecentTransactions)}
-              className="text-tertiary-text"
             />
           </div>
         </div>

--- a/src/app/[locale]/add/stores/useAddLiquidityAmountsStore.ts
+++ b/src/app/[locale]/add/stores/useAddLiquidityAmountsStore.ts
@@ -14,10 +14,14 @@ interface LiquidityAmountsStore {
   typedValue: string;
   dependentField: Field;
   setTypedValue: (data: { typedValue: string; field: Field }) => void;
-  tokenAStandardRatio: 0 | 100;
-  tokenBStandardRatio: 0 | 100;
-  setTokenAStandardRatio: (ratio: 0 | 100) => void;
-  setTokenBStandardRatio: (ratio: 0 | 100) => void;
+  // tokenAStandardRatio: 0 | 100;
+  // tokenBStandardRatio: 0 | 100;
+  tokenAStandardRatio: number;
+  tokenBStandardRatio: number;
+  // setTokenAStandardRatio: (ratio: 0 | 100) => void;
+  // setTokenBStandardRatio: (ratio: 0 | 100) => void;
+  setTokenAStandardRatio: (ratio: number) => void;
+  setTokenBStandardRatio: (ratio: number) => void;
 }
 
 export const useLiquidityAmountsStore = create<LiquidityAmountsStore>((set, get) => ({

--- a/src/app/[locale]/add/stores/useAddLiquidityStatusStore.tsx
+++ b/src/app/[locale]/add/stores/useAddLiquidityStatusStore.tsx
@@ -34,8 +34,8 @@ interface AddLiquidityStatusStore {
   setStatus: (status: AddLiquidityStatus) => void;
   setApprove0Status: (status: AddLiquidityApproveStatus) => void;
   setApprove1Status: (status: AddLiquidityApproveStatus) => void;
-  setApprove0Hash: (hash: Address) => void;
-  setApprove1Hash: (hash: Address) => void;
+  setApprove0Hash: (hash: Address | undefined) => void;
+  setApprove1Hash: (hash: Address | undefined) => void;
   setDeposite0Status: (status: AddLiquidityApproveStatus) => void;
   setDeposite1Status: (status: AddLiquidityApproveStatus) => void;
   setDeposite0Hash: (hash: Address) => void;

--- a/src/app/[locale]/increase/[tokenId]/page.tsx
+++ b/src/app/[locale]/increase/[tokenId]/page.tsx
@@ -9,6 +9,7 @@ import { useLiquidityPriceRangeStore } from "@/app/[locale]/add/stores/useLiquid
 import { useLiquidityTierStore } from "@/app/[locale]/add/stores/useLiquidityTierStore";
 import PositionLiquidityCard from "@/app/[locale]/pool/[tokenId]/components/PositionLiquidityCard";
 import PositionPriceRangeCard from "@/app/[locale]/pool/[tokenId]/components/PositionPriceRangeCard";
+import { useSwapRecentTransactionsStore } from "@/app/[locale]/swap/stores/useSwapRecentTransactions";
 import Container from "@/components/atoms/Container";
 import Svg from "@/components/atoms/Svg";
 import RangeBadge, { PositionRangeStatus } from "@/components/badges/RangeBadge";
@@ -42,7 +43,10 @@ export default function IncreaseLiquidityPage({
   };
 }) {
   useRecentTransactionTracking();
-  const [showRecentTransactions, setShowRecentTransactions] = useState(true);
+  // const [showRecentTransactions, setShowRecentTransactions] = useState(true);
+
+  const { isOpened: showRecentTransactions, setIsOpened: setShowRecentTransactions } =
+    useSwapRecentTransactionsStore();
 
   const { setIsOpen } = useTransactionSettingsDialogStore();
   const { setTicks } = useLiquidityPriceRangeStore();
@@ -129,7 +133,7 @@ export default function IncreaseLiquidityPage({
               buttonSize={IconButtonSize.LARGE}
               iconName="recent-transactions"
               onClick={() => setShowRecentTransactions(!showRecentTransactions)}
-              className={showRecentTransactions ? "text-green" : "text-tertiary-text"}
+              active={showRecentTransactions}
             />
             <IconButton
               buttonSize={IconButtonSize.LARGE}

--- a/src/app/[locale]/pool/[tokenId]/page.tsx
+++ b/src/app/[locale]/pool/[tokenId]/page.tsx
@@ -17,8 +17,8 @@ import Svg from "@/components/atoms/Svg";
 import Tooltip from "@/components/atoms/Tooltip";
 import Badge, { BadgeVariant } from "@/components/badges/Badge";
 import RangeBadge, { PositionRangeStatus } from "@/components/badges/RangeBadge";
-import Button, { ButtonColor, ButtonSize, ButtonVariant } from "@/components/buttons/Button";
-import IconButton, { IconButtonSize, IconButtonVariant } from "@/components/buttons/IconButton";
+import Button, { ButtonColor, ButtonSize } from "@/components/buttons/Button";
+import IconButton, { IconButtonSize } from "@/components/buttons/IconButton";
 import RadioButton from "@/components/buttons/RadioButton";
 import RecentTransactions from "@/components/common/RecentTransactions";
 import SelectedTokensInfo from "@/components/common/SelectedTokensInfo";
@@ -41,7 +41,7 @@ import { useComputePoolAddressDex } from "@/sdk_hybrid/utils/computePoolAddress"
 
 import { CollectFeesGasSettings } from "./components/CollectFeesGasSettings";
 import { CollectFeesStatus, useCollectFeesStatusStore } from "./stores/useCollectFeesStatusStore";
-import { useCollectFeesStore } from "./stores/useCollectFeesStore";
+import { useCollectFeesStore, useRefreshStore } from "./stores/useCollectFeesStore";
 
 export default function PoolPage({
   params,
@@ -58,6 +58,8 @@ export default function PoolPage({
   const { isOpened: showRecentTransactions, setIsOpened: setShowRecentTransactions } =
     useSwapRecentTransactionsStore();
 
+  const { forceRefresh } = useRefreshStore();
+
   const [isOpen, setIsOpen] = useState(false);
 
   const router = useRouter();
@@ -66,7 +68,7 @@ export default function PoolPage({
   const [showFirst, setShowFirst] = useState(true);
 
   const { position: positionInfo, loading } = usePositionFromTokenId(BigInt(params.tokenId));
-  const position = usePositionFromPositionInfo(positionInfo);
+  let position = usePositionFromPositionInfo(positionInfo);
 
   const token0 = position?.pool.token0;
   const token1 = position?.pool.token1;
@@ -88,7 +90,7 @@ export default function PoolPage({
     setPoolAddress,
     setTokenId,
   } = useCollectFeesStore();
-  const { status, hash } = useCollectFeesStatusStore();
+  const { status, hash, setStatus } = useCollectFeesStatusStore();
 
   useEffect(() => {
     setPool(position?.pool);
@@ -107,6 +109,8 @@ export default function PoolPage({
   const handleClose = () => {
     reset();
     setIsOpen(false);
+    forceRefresh();
+    setStatus(CollectFeesStatus.INITIAL);
   };
 
   if (loading || poolAddressLoading) {
@@ -234,7 +238,7 @@ export default function PoolPage({
                 onClick={() => setIsOpen(true)}
                 size={ButtonSize.MEDIUM}
                 mobileSize={ButtonSize.SMALL}
-                disabled={!fees[0]}
+                disabled={!fees[0] && !fees[1]}
               >
                 Collect fees
               </Button>
@@ -431,7 +435,7 @@ export default function PoolPage({
                         <span className="text-14 lg:text-16">Standard</span>
                         <Badge color="green" text="ERC-20" />
                       </div>
-                      <span className="text-14 lg:text-16">{token0FeeFormatted}</span>
+                      <span className="text-14 lg:text-16">{`${token0FeeFormatted} ${token0?.symbol}`}</span>
                     </div>
                   </RadioButton>
                   <RadioButton
@@ -446,7 +450,7 @@ export default function PoolPage({
                         <span className="text-14 lg:text-16">Standard</span>
                         <Badge color="green" text="ERC-223" />
                       </div>
-                      <span className="text-14 lg:text-16">{token0FeeFormatted}</span>
+                      <span className="text-14 lg:text-16">{`${token0FeeFormatted} ${token0?.symbol}`}</span>
                     </div>
                   </RadioButton>
                 </div>

--- a/src/app/[locale]/pool/[tokenId]/page.tsx
+++ b/src/app/[locale]/pool/[tokenId]/page.tsx
@@ -7,6 +7,7 @@ import { formatUnits } from "viem";
 
 import PositionLiquidityCard from "@/app/[locale]/pool/[tokenId]/components/PositionLiquidityCard";
 import PositionPriceRangeCard from "@/app/[locale]/pool/[tokenId]/components/PositionPriceRangeCard";
+import { useSwapRecentTransactionsStore } from "@/app/[locale]/swap/stores/useSwapRecentTransactions";
 import Alert from "@/components/atoms/Alert";
 import Container from "@/components/atoms/Container";
 import DialogHeader from "@/components/atoms/DialogHeader";
@@ -17,7 +18,7 @@ import Tooltip from "@/components/atoms/Tooltip";
 import Badge, { BadgeVariant } from "@/components/badges/Badge";
 import RangeBadge, { PositionRangeStatus } from "@/components/badges/RangeBadge";
 import Button, { ButtonColor, ButtonSize, ButtonVariant } from "@/components/buttons/Button";
-import IconButton, { IconButtonSize } from "@/components/buttons/IconButton";
+import IconButton, { IconButtonSize, IconButtonVariant } from "@/components/buttons/IconButton";
 import RadioButton from "@/components/buttons/RadioButton";
 import RecentTransactions from "@/components/common/RecentTransactions";
 import SelectedTokensInfo from "@/components/common/SelectedTokensInfo";
@@ -53,7 +54,10 @@ export default function PoolPage({
   useCollectFeesEstimatedGas();
 
   const chainId = useCurrentChainId();
-  const [showRecentTransactions, setShowRecentTransactions] = useState(true);
+  // const [showRecentTransactions, setShowRecentTransactions] = useState(true);
+  const { isOpened: showRecentTransactions, setIsOpened: setShowRecentTransactions } =
+    useSwapRecentTransactionsStore();
+
   const [isOpen, setIsOpen] = useState(false);
 
   const router = useRouter();

--- a/src/app/[locale]/pool/[tokenId]/stores/useCollectFeesStore.ts
+++ b/src/app/[locale]/pool/[tokenId]/stores/useCollectFeesStore.ts
@@ -19,6 +19,16 @@ interface CollectFeesStore {
   reset: () => void;
 }
 
+interface RefreshStore {
+  refreshKey: number;
+  forceRefresh: () => void;
+}
+
+export const useRefreshStore = create<RefreshStore>((set) => ({
+  refreshKey: 0,
+  forceRefresh: () => set((state) => ({ refreshKey: state.refreshKey + 1 })),
+}));
+
 export const useCollectFeesStore = create<CollectFeesStore>((set, get) => ({
   token0Standard: Standard.ERC20,
   token1Standard: Standard.ERC20,

--- a/src/app/[locale]/pools/PoolsTable.tsx
+++ b/src/app/[locale]/pools/PoolsTable.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import Image from "next/image";
-import { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Address } from "viem";
 
 import Preloader from "@/components/atoms/Preloader";
@@ -87,7 +87,7 @@ const PoolsTableDesktop = ({
 
       {tableData.map((o: any, index: number) => {
         return (
-          <>
+          <React.Fragment key={o.id}>
             <div
               onClick={() => openPoolHandler(o.id)}
               className="h-[56px] cursor-pointer flex items-center justify-center"
@@ -132,7 +132,7 @@ const PoolsTableDesktop = ({
             >
               ${formatFloat(0)}
             </div>
-          </>
+          </React.Fragment>
         );
       })}
     </div>
@@ -140,16 +140,18 @@ const PoolsTableDesktop = ({
 };
 
 const PoolsTableItemMobile = ({
+  key,
   pool,
   openPoolHandler,
   index,
 }: {
+  key: any;
   pool: any;
   openPoolHandler: (id: Address) => any;
   index: number;
 }) => {
   return (
-    <>
+    <React.Fragment key={key}>
       <div className="flex flex-col bg-primary-bg p-4 rounded-3 gap-3">
         <div className="flex justify-between gap-2">
           <div className="flex items-center gap-2 text-14">
@@ -204,15 +206,13 @@ const PoolsTableItemMobile = ({
           View pool
         </Button>
       </div>
-    </>
+    </React.Fragment>
   );
 };
 
 const PoolsTableMobile = ({
   tableData,
   currentPage,
-  sorting,
-  handleSort,
   openPoolHandler,
 }: {
   tableData: any[];
@@ -263,7 +263,7 @@ export default function PoolsTable({
   const [currentPage, setCurrentPage] = useState(1);
 
   const chainId = useCurrentChainId();
-  const { data, loading, ...restData } = usePoolsData({
+  const { data, loading } = usePoolsData({
     chainId,
     orderDirection: GQLSorting[sorting],
     filter,

--- a/src/app/[locale]/portfolio/components/Balances/BalancesTable.tsx
+++ b/src/app/[locale]/portfolio/components/Balances/BalancesTable.tsx
@@ -28,7 +28,7 @@ export const BalancesDesktopTable = ({
       <div className="text-secondary-text pr-5 h-[60px] flex items-center justify-end">Details</div>
       {tableData.map((o: any, index: number) => {
         const key = o?.token?.address0 ? o.token.address0 : `item-${index}`;
-        
+
         return (
           <React.Fragment key={key}>
             <div
@@ -87,7 +87,7 @@ export const BalancesMobileTable = ({
     <div className="flex lg:hidden flex-col gap-4">
       {tableData.map((o: any, index: number) => {
         const key = o?.token?.address0 ? o.token.address0 : `item-${index}`;
-        
+
         return (
           <div className="flex flex-col bg-primary-bg p-4 rounded-3 gap-2" key={key}>
             <div className="flex justify-start items-start gap-1">

--- a/src/app/[locale]/portfolio/components/Balances/BalancesTable.tsx
+++ b/src/app/[locale]/portfolio/components/Balances/BalancesTable.tsx
@@ -27,8 +27,10 @@ export const BalancesDesktopTable = ({
       <div className="text-secondary-text h-[60px] flex items-center">Amount, $</div>
       <div className="text-secondary-text pr-5 h-[60px] flex items-center justify-end">Details</div>
       {tableData.map((o: any, index: number) => {
+        const key = o?.token?.address0 ? o.token.address0 : `item-${index}`;
+        
         return (
-          <React.Fragment key={o.token.address0}>
+          <React.Fragment key={key}>
             <div
               className={clsx(
                 "h-[56px] flex items-center gap-2 pl-5 rounded-l-3",
@@ -84,8 +86,10 @@ export const BalancesMobileTable = ({
   return (
     <div className="flex lg:hidden flex-col gap-4">
       {tableData.map((o: any, index: number) => {
+        const key = o?.token?.address0 ? o.token.address0 : `item-${index}`;
+        
         return (
-          <div className="flex flex-col bg-primary-bg p-4 rounded-3 gap-2" key={o.token.address0}>
+          <div className="flex flex-col bg-primary-bg p-4 rounded-3 gap-2" key={key}>
             <div className="flex justify-start items-start gap-1">
               <div className="flex gap-2">
                 <Image src={o.logoURI || "/tokens/placeholder.svg"} width={32} height={32} alt="" />

--- a/src/app/[locale]/portfolio/components/Balances/index.tsx
+++ b/src/app/[locale]/portfolio/components/Balances/index.tsx
@@ -13,7 +13,6 @@ import Tooltip from "@/components/atoms/Tooltip";
 import { TokenPortfolioDialogContent } from "@/components/dialogs/TokenPortfolioDialog";
 import { formatFloat } from "@/functions/formatFloat";
 import { Currency } from "@/sdk_hybrid/entities/currency";
-import { Token } from "@/sdk_hybrid/entities/token";
 
 import { useActiveWalletBalances } from "../../stores/balances.hooks";
 import { BalancesDesktopTable, BalancesMobileTable } from "./BalancesTable";

--- a/src/app/[locale]/remove/[tokenId]/page.tsx
+++ b/src/app/[locale]/remove/[tokenId]/page.tsx
@@ -9,6 +9,7 @@ import { useAccount } from "wagmi";
 import useRemoveLiquidity, {
   useRemoveLiquidityEstimatedGas,
 } from "@/app/[locale]/remove/[tokenId]/hooks/useRemoveLiquidity";
+import { useSwapRecentTransactionsStore } from "@/app/[locale]/swap/stores/useSwapRecentTransactions";
 import Alert from "@/components/atoms/Alert";
 import Container from "@/components/atoms/Container";
 import DialogHeader from "@/components/atoms/DialogHeader";
@@ -17,7 +18,7 @@ import Preloader from "@/components/atoms/Preloader";
 import Svg from "@/components/atoms/Svg";
 import RangeBadge, { PositionRangeStatus } from "@/components/badges/RangeBadge";
 import Button from "@/components/buttons/Button";
-import IconButton, { IconButtonSize, IconSize } from "@/components/buttons/IconButton";
+import IconButton, { IconButtonSize, IconButtonVariant, IconSize } from "@/components/buttons/IconButton";
 import InputButton from "@/components/buttons/InputButton";
 import RecentTransactions from "@/components/common/RecentTransactions";
 import SelectedTokensInfo from "@/components/common/SelectedTokensInfo";
@@ -93,7 +94,10 @@ export default function DecreaseLiquidityPage({
   }, [position?.pool.fee, position?.pool.token0, position?.pool.token1]);
 
   const { inRange, removed } = usePositionRangeStatus({ position });
-  const [showRecentTransactions, setShowRecentTransactions] = useState(true);
+  // const [showRecentTransactions, setShowRecentTransactions] = useState(true);
+
+  const { isOpened: showRecentTransactions, setIsOpened: setShowRecentTransactions } =
+    useSwapRecentTransactionsStore();
 
   const {
     reset,

--- a/src/app/[locale]/remove/[tokenId]/page.tsx
+++ b/src/app/[locale]/remove/[tokenId]/page.tsx
@@ -18,7 +18,7 @@ import Preloader from "@/components/atoms/Preloader";
 import Svg from "@/components/atoms/Svg";
 import RangeBadge, { PositionRangeStatus } from "@/components/badges/RangeBadge";
 import Button from "@/components/buttons/Button";
-import IconButton, { IconButtonSize, IconButtonVariant, IconSize } from "@/components/buttons/IconButton";
+import IconButton, { IconButtonSize, IconSize } from "@/components/buttons/IconButton";
 import InputButton from "@/components/buttons/InputButton";
 import RecentTransactions from "@/components/common/RecentTransactions";
 import SelectedTokensInfo from "@/components/common/SelectedTokensInfo";

--- a/src/app/[locale]/swap/components/TradeForm.tsx
+++ b/src/app/[locale]/swap/components/TradeForm.tsx
@@ -20,7 +20,7 @@ import { useSwapTokensStore } from "@/app/[locale]/swap/stores/useSwapTokensStor
 import Preloader from "@/components/atoms/Preloader";
 import Tooltip from "@/components/atoms/Tooltip";
 import Button, { ButtonColor, ButtonSize } from "@/components/buttons/Button";
-import IconButton, { IconButtonSize } from "@/components/buttons/IconButton";
+import IconButton, { IconButtonSize, IconButtonVariant } from "@/components/buttons/IconButton";
 import SwapButton from "@/components/buttons/SwapButton";
 import TokenInput from "@/components/common/TokenInput";
 import NetworkFeeConfigDialog from "@/components/dialogs/NetworkFeeConfigDialog";

--- a/src/app/[locale]/swap/page.tsx
+++ b/src/app/[locale]/swap/page.tsx
@@ -47,16 +47,14 @@ export default function SwapPage() {
               : "xl:grid-cols-[600px] xl:max-w-[600px] grid-areas-[right]",
           )}
         >
-          {showRecentTransactions && (
-            <div className="grid-in-[left] flex justify-center">
-              <div className="w-full sm:max-w-[600px] xl:max-w-full">
-                <RecentTransactions
-                  showRecentTransactions={showRecentTransactions}
-                  handleClose={() => setShowRecentTransactions(false)}
-                />
-              </div>
+          <div className="grid-in-[left] flex justify-center">
+            <div className="w-full sm:max-w-[600px] xl:max-w-full">
+              <RecentTransactions
+                showRecentTransactions={showRecentTransactions}
+                handleClose={() => setShowRecentTransactions(false)}
+              />
             </div>
-          )}
+          </div>
 
           <div className="flex justify-center grid-in-[right]">
             <div className="flex flex-col gap-5 w-full sm:max-w-[600px] xl:max-w-full">

--- a/src/app/[locale]/token-listing/add/page.tsx
+++ b/src/app/[locale]/token-listing/add/page.tsx
@@ -38,7 +38,7 @@ import Svg from "@/components/atoms/Svg";
 import { HelperText, InputLabel } from "@/components/atoms/TextField";
 import Badge, { BadgeVariant } from "@/components/badges/Badge";
 import Button, { ButtonColor, ButtonSize } from "@/components/buttons/Button";
-import IconButton, { IconButtonSize } from "@/components/buttons/IconButton";
+import IconButton, { IconButtonSize, IconButtonVariant } from "@/components/buttons/IconButton";
 import RecentTransactions from "@/components/common/RecentTransactions";
 import NetworkFeeConfigDialog from "@/components/dialogs/NetworkFeeConfigDialog";
 import PickTokenDialog from "@/components/dialogs/PickTokenDialog";
@@ -346,16 +346,14 @@ export default function ListTokenPage() {
               : "xl:grid-cols-[600px] xl:max-w-[600px] grid-areas-[right]",
           )}
         >
-          {showRecentTransactions && (
-            <div className="grid-in-[left] flex justify-center">
-              <div className="w-full sm:max-w-[600px] xl:max-w-full">
-                <RecentTransactions
-                  showRecentTransactions={showRecentTransactions}
-                  handleClose={() => setShowRecentTransactions(false)}
-                />
-              </div>
+          <div className="grid-in-[left] flex justify-center">
+            <div className="w-full sm:max-w-[600px] xl:max-w-full">
+              <RecentTransactions
+                showRecentTransactions={showRecentTransactions}
+                handleClose={() => setShowRecentTransactions(false)}
+              />
             </div>
-          )}
+          </div>
 
           <div className="flex justify-center grid-in-[right]">
             <div className="flex flex-col gap-5 w-full sm:max-w-[600px] xl:max-w-full">

--- a/src/components/buttons/IconButton.tsx
+++ b/src/components/buttons/IconButton.tsx
@@ -107,12 +107,16 @@ function CopyIconButton(_props: CopyIconButtonProps) {
   const { text, buttonSize, className, ...props } = _props;
 
   const handleCopy = useCallback(async () => {
-    await copyToClipboard(text);
-    setIsCopied(true);
-    addToast(t("successfully_copied"));
-    setTimeout(() => {
-      setIsCopied(false);
-    }, 800);
+    try {
+      await copyToClipboard(text);
+      setIsCopied(true);
+      addToast(t("successfully_copied"));
+      setTimeout(() => {
+        setIsCopied(false);
+      }, 800);
+    } catch (e) {
+      addToast("Clipboard API not supported", "error");
+    }
   }, [t, text]);
 
   return (

--- a/src/components/buttons/IconButton.tsx
+++ b/src/components/buttons/IconButton.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from "next-intl";
-import { ButtonHTMLAttributes, useCallback, useState, useEffect } from "react";
+import { ButtonHTMLAttributes, useCallback, useEffect, useState } from "react";
 import { MouseEvent } from "react";
 
 import { SortingType } from "@/app/[locale]/borrow-market/components/BorrowMarketTable";
@@ -70,7 +70,6 @@ export enum IconButtonVariant {
   COPY,
   SORTING,
   ADD,
-  NOHOVER 
 }
 
 type Props = ButtonHTMLAttributes<HTMLButtonElement> &

--- a/src/components/buttons/IconButton.tsx
+++ b/src/components/buttons/IconButton.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from "next-intl";
-import { ButtonHTMLAttributes, useCallback, useState } from "react";
+import { ButtonHTMLAttributes, useCallback, useState, useEffect } from "react";
 import { MouseEvent } from "react";
 
 import { SortingType } from "@/app/[locale]/borrow-market/components/BorrowMarketTable";
@@ -70,6 +70,7 @@ export enum IconButtonVariant {
   COPY,
   SORTING,
   ADD,
+  NOHOVER 
 }
 
 type Props = ButtonHTMLAttributes<HTMLButtonElement> &
@@ -129,6 +130,14 @@ function CopyIconButton(_props: CopyIconButtonProps) {
   );
 }
 export default function IconButton(_props: Props) {
+  const [isTouchDevice, setIsTouchDevice] = useState(false);
+
+  useEffect(() => {
+    if ("ontouchstart" in window || navigator.maxTouchPoints > 0) {
+      setIsTouchDevice(true);
+    }
+  }, []);
+
   switch (_props.variant) {
     case IconButtonVariant.DEFAULT:
     case undefined: {
@@ -137,8 +146,9 @@ export default function IconButton(_props: Props) {
         <IconButtonFrame
           iconName={_props.iconName}
           className={clsxMerge(
-            "text-tertiary-text  hocus:text-green-hover-icon relative before:opacity-0 before:duration-200 hocus:before:opacity-60 before:absolute before:w-4 before:h-4 before:rounded-full before:bg-green-hover-icon before:blur-[9px] duration-200",
+            "text-tertiary-text relative before:opacity-0 before:duration-200 hocus:before:opacity-60 before:absolute before:w-4 before:h-4 before:rounded-full before:blur-[9px] duration-200",
             active && "text-green",
+            !isTouchDevice && "hocus:text-green-hover-icon before:bg-green-hover-icon",
             className,
           )}
           {...props}

--- a/src/components/common/RecentTransactions.tsx
+++ b/src/components/common/RecentTransactions.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useAccount } from "wagmi";
 
 import IconButton, { IconButtonVariant } from "@/components/buttons/IconButton";
@@ -27,6 +27,24 @@ export default function RecentTransactions({
 
   const { transactions } = useRecentTransactionsStore();
   const { address } = useAccount();
+
+  const componentRef = useRef<HTMLDivElement>(null);
+  const prevShowRecentTransactions = useRef(showRecentTransactions);
+
+  useEffect(() => {
+    // Check if switching from non-visible to visible
+    if (!prevShowRecentTransactions.current && showRecentTransactions && componentRef.current) {
+      const rect = componentRef.current.getBoundingClientRect();
+      const isVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
+
+      if (!isVisible) {
+        componentRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    }
+
+    // Update the previous value for the next render
+    prevShowRecentTransactions.current = showRecentTransactions;
+  }, [showRecentTransactions]);
 
   const lowestPendingNonce = useMemo(() => {
     if (address) {
@@ -65,7 +83,7 @@ export default function RecentTransactions({
   return (
     <>
       {showRecentTransactions && (
-        <div>
+        <div ref={componentRef}>
           <div className="px-4 md:px-10 pt-2.5 pb-5 bg-primary-bg rounded-5">
             <div className="flex justify-between items-center mb-2.5">
               <h3 className="font-bold text-20">{t("transactions")}</h3>

--- a/src/functions/copyToClipboard.ts
+++ b/src/functions/copyToClipboard.ts
@@ -1,3 +1,7 @@
 export async function copyToClipboard(text: string) {
-  await navigator.clipboard.writeText(text);
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (error) {
+    throw new Error("Clipboard API not supported");
+  }
 }

--- a/src/hooks/useCollectFees.ts
+++ b/src/hooks/useCollectFees.ts
@@ -12,6 +12,7 @@ import {
 } from "@/app/[locale]/pool/[tokenId]/stores/useCollectFeesStatusStore";
 import {
   useCollectFeesStore,
+  useRefreshStore,
   useTokensOutCode,
 } from "@/app/[locale]/pool/[tokenId]/stores/useCollectFeesStore";
 import { NONFUNGIBLE_POSITION_MANAGER_ABI } from "@/config/abis/nonfungiblePositionManager";
@@ -22,7 +23,6 @@ import { CurrencyAmount } from "@/sdk_hybrid/entities/fractions/currencyAmount";
 import { Token } from "@/sdk_hybrid/entities/token";
 import { Standard } from "@/sdk_hybrid/standard";
 import {
-  GasFeeModel,
   RecentTransactionTitleTemplate,
   stringifyObject,
   useRecentTransactionsStore,
@@ -40,6 +40,7 @@ const useCollectFees = () => {
   const chainId = useCurrentChainId();
   const { address } = useAccount();
   const recipient = address || ZERO_ADDRESS;
+  const { refreshKey } = useRefreshStore();
 
   const { data: collectResult } = useSimulateContract({
     address: NONFUNGIBLE_POSITION_MANAGER_ADDRESS[chainId as DexChainId],
@@ -58,14 +59,14 @@ const useCollectFees = () => {
     query: {
       enabled: Boolean(tokenId),
     },
+    // @ts-ignore
+    dependencies: [tokenId, refreshKey],
   });
 
-  const fees = useMemo(() => {
+  return useMemo(() => {
     if (!pool || !collectResult?.result) return [undefined, undefined] as [undefined, undefined];
     return [collectResult?.result[0], collectResult?.result[1]] as [bigint, bigint];
   }, [pool, collectResult]);
-
-  return fees;
 };
 
 const useCollectFeesParams = () => {

--- a/src/stories/atoms/InputRange.stories.tsx
+++ b/src/stories/atoms/InputRange.stories.tsx
@@ -16,7 +16,7 @@ export const Default: Story = {
   render: function Render(args) {
     const [{ value }, updateArgs] = useArgs();
 
-    function onChange(value: 0 | 100) {
+    function onChange(value: number) {
       updateArgs({ value });
     }
 


### PR DESCRIPTION
(+k) 131. KeyStore: mint liquidity (ERC20-ERC20). On approving second token got approved, and first - was not. Had to press Approve again.
(+k) . Не очевидно действие кнопки отображения транзакций. Т.е. на нее кликаю, она активируется - но что произошло - непонятно, т.к. список отобразился внизу страницы и понять что он там появился нет возможности. М.б. стоит сделать на него перемотку?
(+k) . Кнопка "отображения транзакций". При первом нажатии - подсвечивается и список появляется (см. выше). При повторном нажатии - список скрывается. Но кнопка остается активированной. Подсветка кнопки соотвествует статусу "наведения курсора", а не статусу "активен". Если список закрыть "крестиком" на самом списке - вид кнопки/иконки возвращается к "неактивен".
(+k) . Сохраняется статус диалога со списком транзакций при переходе между страницами (взял у Вити - пока один статус на все страницы)
(+k) 67. Changing the token standard on Add Liquidity page
(+k) 148. Pools Approve transactions set default
(+k) 170. Pools. Collected fee
(+k) can't collect Fee if first token fee = 0
(+k) one token value shown with token symbol - other without
(+k) "close" button does not revert to normal state
(+k) 174. Mobile. Portfolio balances
(+/-k) 174.1. Does not work copy to clipboard on MM Mobile - added error message
(+k) 203. Add liquidity. In metamask browser from phone if there are two ERC20 tokens, then only one request for approval is sent instead of two
(+k) 230. Add liquidity. In Approve popup for new approves remains links to transactions from previous approvals.
(+k) 231. Add liquidity. Icon "Show transactions" does not change state whenever transactions are shown or not
(+k) Pools list. Fixed table generation bug (added key to elements).